### PR TITLE
Publish allocation updates if alloc was modified after last task event

### DIFF
--- a/command/allocations/app.go
+++ b/command/allocations/app.go
@@ -194,7 +194,7 @@ func (f *Firehose) watch() {
 						TaskFailed:         taskInfo.Failed,
 						TaskStartedAt:      &taskInfo.StartedAt,
 						TaskFinishedAt:     &taskInfo.FinishedAt,
-						ModifyTime:         allocation.ModifyTime
+						ModifyTime:         allocation.ModifyTime,
 					}
 
 					f.publish(payload)
@@ -202,6 +202,11 @@ func (f *Firehose) watch() {
 				}
 
 				if !has_published && allocation.ModifyTime >= f.lastChangeTime {
+
+					if allocation.ModifyTime > newMax {
+						newMax = allocation.ModifyTime
+					}
+
 					payload := &AllocationUpdate{
 						Name:               allocation.Name,
 						NodeID:             allocation.NodeID,


### PR DESCRIPTION
E.g. for test_runner job, this would publish an additional message for when the allocation changes clientStatus (for either the log_collector or test task, it doesn't differentiate).

the taskEvent would be empty since there's no associated taskState, but we can accommodate for that in our code.